### PR TITLE
updates csv parser to skip blank lines …

### DIFF
--- a/src/de/najidev/mensaupb/stw/StwParser.java
+++ b/src/de/najidev/mensaupb/stw/StwParser.java
@@ -27,7 +27,7 @@ public class StwParser {
             String[] parts = prepareNextLine(sc);
             if(skipThisLine(parts)) {
                 continue;
-            }else{
+            } else {
             ContentValues menu = parseLine(parts);
             parsedMenus.add(menu);
             }
@@ -39,7 +39,7 @@ public class StwParser {
 
     private static boolean skipThisLine(String[] parts) {
         if(BuildConfig.DEBUG) LOGGER.debug("skipThisLine(..): \"Mensa Hamm\" == {}",parts[1]);
-        return TextUtils.equals("Mensa Hamm", parts[1]);
+        return parts.length < 9 || TextUtils.equals("Mensa Hamm", parts[1]);
     }
 
     private static String[] prepareNextLine(Scanner sc) {


### PR DESCRIPTION
… or lines with less than nine columns.
:arrow_right: prevents an IndexOutOfBounceException.

see https://github.com/dirkschumacher/iUPB/commit/721cba72d23ef71f74aee596367df4220f8c04ce for a comparable change to iUPB, where the invalid stwpb csv file blew up production last weekend…
